### PR TITLE
Improve agent handoffs and context sharing

### DIFF
--- a/The_Agents/ArchitectAgent.py
+++ b/The_Agents/ArchitectAgent.py
@@ -77,6 +77,7 @@ from Tools.architect_tools import (
 
 # Import custom context data model
 from The_Agents.context_data import EnhancedContextData
+from agents.extensions.handoff_prompt import RECOMMENDED_PROMPT_PREFIX
 
 
 class ArchitectAgent:
@@ -177,8 +178,9 @@ class ArchitectAgent:
     Returns:
         String with detailed instruction set
     """
-        return """You are an Architecture Expert Assistant specialized in software design, architecture analysis, 
-and code organization. Your purpose is to help developers understand, design, and implement 
+        return f"""{RECOMMENDED_PROMPT_PREFIX}
+You are an Architecture Expert Assistant specialized in software design, architecture analysis,
+and code organization. Your purpose is to help developers understand, design, and implement
 better software architectures.
 
 CAPABILITIES:

--- a/The_Agents/SingleAgent.py
+++ b/The_Agents/SingleAgent.py
@@ -95,12 +95,13 @@ from agents.exceptions import MaxTurnsExceeded
 
 # Import our enhanced context
 from The_Agents.context_data import EnhancedContextData
+from agents.extensions.handoff_prompt import RECOMMENDED_PROMPT_PREFIX
 
 # Path for persistent context storage
 CONTEXT_FILE_PATH = os.path.join(os.path.expanduser("~"), ".singleagent_context.json")
 
 # Constants
-AGENT_INSTRUCTIONS = """
+AGENT_INSTRUCTIONS = f"""{RECOMMENDED_PROMPT_PREFIX}
 You are a code assistant capable of helping users write, edit, and patch code.
 You have full control of the terminal and can run commands like sed, grep, ls, dir, cd, tail, python, and bash.
 You can analyze code with pylint, ruff and pyright, generate colored diffs, and apply patches to files.

--- a/main.py
+++ b/main.py
@@ -122,6 +122,12 @@ async def main():
         # Mode switching commands
         if query.strip().lower() == "!architect" and current_mode == AgentMode.CODE:
             # Switch to architect mode
+            summary = code_agent.get_context_summary()
+            architect_agent.context.add_manual_context(
+                content=summary,
+                source="code_agent",
+                label="handoff_from_code"
+            )
             current_mode = AgentMode.ARCHITECT
             # Save context before switching
             await code_agent.save_context()
@@ -131,6 +137,12 @@ async def main():
             continue
         elif query.strip().lower() == "!code" and current_mode == AgentMode.ARCHITECT:
             # Switch to code mode
+            summary = architect_agent.get_context_summary()
+            code_agent.context.add_manual_context(
+                content=summary,
+                source="architect_agent",
+                label="handoff_from_architect"
+            )
             current_mode = AgentMode.CODE
             # Save context before switching
             await architect_agent.save_context()

--- a/utilities/tool_usage.py
+++ b/utilities/tool_usage.py
@@ -96,7 +96,10 @@ def handle_entity_tracking(context, tool_name: str, tool_params: Any) -> None:
     if tool_name and tool_params and hasattr(context, "track_entity"):
         if tool_name in ("os_command", "run_command"):
             if isinstance(tool_params, dict) and "command" in tool_params:
-                context.track_entity("command", tool_params["command"])
+                cmd = tool_params["command"]
+                context.track_entity("command", cmd)
+                if hasattr(context, "remember_command"):
+                    context.remember_command(cmd, "")
         elif tool_name == "read_file":
             if isinstance(tool_params, dict) and "file_path" in tool_params:
                 context.track_entity("file", tool_params["file_path"])
@@ -112,20 +115,18 @@ def track_file_from_output(context, output: Dict[str, Any]) -> None:
     if hasattr(context, "track_entity") and isinstance(output, dict):
         if 'file_path' in output and 'content' in output:
             context.track_entity(
-                "file", 
-                output['file_path'], 
+                "file",
+                output['file_path'],
                 {"content_preview": output['content'][:100] if output['content'] else None}
             )
+            if hasattr(context, "remember_file"):
+                context.remember_file(output['file_path'], output['content'])
 
 def display_agent_handoff(new_agent_name: str) -> None:
-    """
-    Display agent handoff notification.
-    
-    Args:
-        new_agent_name: Name of the agent being handed off to
-    """
-    handoff_status = f"{BLUE}→{RESET}"  # Handoff indicator
-    print(f"\n{handoff_status} Handoff to {new_agent_name}", flush=True)
+    """Display a visible banner when control switches to another agent."""
+    handoff_status = f"{BLUE}{BOLD}→{RESET}"
+    banner = f"{handoff_status} Switched to {BOLD}{new_agent_name}{RESET}"
+    print(f"\n{banner}\n{'-' * len(banner)}", flush=True)
 
 def display_thinking_animation(thinking_chars: list, thinking_index: int) -> int:
     """


### PR DESCRIPTION
## Summary
- include handoff prompt prefix in code and architect agents
- remember file and command activity in context during streaming
- print clearer banner when agents hand off
- share context summary when switching modes

## Testing
- `python -m py_compile The_Agents/SingleAgent.py The_Agents/ArchitectAgent.py utilities/tool_usage.py main.py`