### PR TITLE
Improve agent handoff with shared context

### DIFF
--- a/The_Agents/SearchAgent.py
+++ b/The_Agents/SearchAgent.py
@@ -35,9 +35,10 @@ CONTEXT_FILE_PATH = os.path.join(os.path.expanduser("~"), ".searchagent_context.
 class SearchAgent:
     """Agent responsible for web searches."""
 
-    def __init__(self) -> None:
+    def __init__(self, context: EnhancedContextData | None = None, context_path: str = CONTEXT_FILE_PATH) -> None:
         cwd = os.getcwd()
-        self.context = EnhancedContextData(
+        self.context_path = context_path
+        self.context = context or EnhancedContextData(
             working_directory=cwd,
             project_name=os.path.basename(cwd),
             project_info=discover_project_info(cwd),
@@ -59,14 +60,16 @@ class SearchAgent:
         )
 
     async def _load_context(self) -> None:
+        if self.context:
+            return
         try:
-            self.context = await EnhancedContextData.load_from_json(CONTEXT_FILE_PATH)
+            self.context = await EnhancedContextData.load_from_json(self.context_path)
         except Exception:
             pass
 
     async def save_context(self) -> None:
         try:
-            await self.context.save_to_json(CONTEXT_FILE_PATH)
+            await self.context.save_to_json(self.context_path)
         except Exception as e:
             logger.error(f"Failed to save context: {e}")
 

--- a/The_Agents/WebBrowserAgent.py
+++ b/The_Agents/WebBrowserAgent.py
@@ -21,9 +21,10 @@ Always prefer using tools to gather information rather than guessing.
 CONTEXT_FILE_PATH = os.path.join(os.path.expanduser("~"), ".webbrowser_context.json")
 
 class WebBrowserAgent:
-    def __init__(self):
+    def __init__(self, context: EnhancedContextData | None = None, context_path: str = CONTEXT_FILE_PATH):
         cwd = os.getcwd()
-        self.context = EnhancedContextData(
+        self.context_path = context_path
+        self.context = context or EnhancedContextData(
             working_directory=cwd,
             project_name=os.path.basename(cwd),
             project_info=discover_project_info(cwd),
@@ -39,14 +40,16 @@ class WebBrowserAgent:
         )
 
     async def _load_context(self):
+        if self.context:
+            return
         try:
-            self.context = await EnhancedContextData.load_from_json(CONTEXT_FILE_PATH)
+            self.context = await EnhancedContextData.load_from_json(self.context_path)
         except Exception:
             pass
 
     async def save_context(self):
         try:
-            await self.context.save_to_json(CONTEXT_FILE_PATH)
+            await self.context.save_to_json(self.context_path)
         except Exception as e:
             logger.error(f"Failed to save context: {e}")
 

--- a/The_Agents/context_data.py
+++ b/The_Agents/context_data.py
@@ -328,14 +328,35 @@ class EnhancedContextData(BaseModel):
         self.last_updated = time.time()
 
     def get_state(self, key: str, default: Any = None) -> Any:
-        """
-        Get a value from the session state dictionary.
-        
-        Args:
-            key: State key to retrieve
-            default: Default value if key doesn't exist
-            
-        Returns:
-            The stored value or default if not found
-        """
+        """Return a value from the session state dictionary."""
         return self.session_state.get(key, default)
+
+    # ----- SERIALIZATION -----
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serializable dictionary of the context."""
+        return self.model_dump()
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "EnhancedContextData":
+        """Create an instance from a dictionary."""
+        return cls(**data)
+
+    @classmethod
+    async def load_from_json(cls, path: str) -> "EnhancedContextData":
+        """Load context from a JSON file if it exists."""
+        if os.path.exists(path):
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                return cls.from_dict(data)
+            except Exception:
+                pass
+        return cls()
+
+    async def save_to_json(self, path: str) -> None:
+        """Persist the context to a JSON file."""
+        try:
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(self.to_dict(), f)
+        except Exception as e:
+            logger.error(f"Failed to save context to {path}: {e}")

--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ from The_Agents.spacy_singleton import SpacyModelSingleton, nlp_singleton
 from The_Agents.SingleAgent import SingleAgent
 from The_Agents.ArchitectAgent import ArchitectAgent
 from The_Agents.WebBrowserAgent import WebBrowserAgent
+from The_Agents.context_data import EnhancedContextData
 
 # ANSI escape codes
 GREEN = "\033[32m"
@@ -60,11 +61,15 @@ async def main():
     print(f"{YELLOW}Initializing spaCy model (this may take a moment)...{RESET}")
     await nlp_singleton.initialize(model_name="en_core_web_lg", disable=["parser"])
     
+    # Load or create shared context
+    shared_path = os.path.join(os.path.expanduser("~"), ".agent_shared_context.json")
+    shared_context = await EnhancedContextData.load_from_json(shared_path)
+
     # Start in code agent mode by default
     current_mode = AgentMode.CODE
-    code_agent = SingleAgent()
-    architect_agent = ArchitectAgent()
-    browser_agent = WebBrowserAgent()
+    browser_agent = WebBrowserAgent(context=shared_context, context_path=shared_path)
+    code_agent = SingleAgent(context=shared_context, context_path=shared_path, browser_agent=browser_agent)
+    architect_agent = ArchitectAgent(context=shared_context, context_path=shared_path)
     
     print(f"{BOLD}Multi-Agent system initialized.{RESET}")
     print(f"{GREEN}Currently in {BOLD}Code Agent{RESET}{GREEN} mode.{RESET}")

--- a/utilities/tool_usage.py
+++ b/utilities/tool_usage.py
@@ -123,10 +123,9 @@ def track_file_from_output(context, output: Dict[str, Any]) -> None:
                 context.remember_file(output['file_path'], output['content'])
 
 def display_agent_handoff(new_agent_name: str) -> None:
-    """Display a visible banner when control switches to another agent."""
-    handoff_status = f"{BLUE}{BOLD}→{RESET}"
-    banner = f"{handoff_status} Switched to {BOLD}{new_agent_name}{RESET}"
-    print(f"\n{banner}\n{'-' * len(banner)}", flush=True)
+    """Display a prominent banner when control switches to another agent."""
+    banner = f"{BLUE}{BOLD}>>> HANDOFF TO {new_agent_name} <<<{RESET}"
+    print(f"\n{banner}\n{'=' * len(banner)}", flush=True)
 
 def display_thinking_animation(thinking_chars: list, thinking_index: int) -> int:
     """


### PR DESCRIPTION
## Summary
- implement serialization helpers in `EnhancedContextData`
- improve handoff banner visuals
- allow agents to share a context instance
- wire WebBrowserAgent as a handoff target for SingleAgent
- load a single shared context in `main.py`

## Testing
- `python -m py_compile The_Agents/*.py main.py utilities/tool_usage.py`