### PR TITLE
Add tracing support with CLI toggle

### DIFF
--- a/Docs/index.md
+++ b/Docs/index.md
@@ -50,3 +50,15 @@ print(result.final_output)
 ```bash
 export OPENAI_API_KEY=sk-...
 ```
+
+## Tracing
+
+To capture detailed traces of each agent run, launch the system with the
+`--trace` flag:
+
+```bash
+python main.py --trace --trace-dir traces
+```
+
+Traces are saved in the specified directory and can be visualized with the
+OpenAI Agents SDK tooling.

--- a/The_Agents/ArchitectAgent.py
+++ b/The_Agents/ArchitectAgent.py
@@ -230,7 +230,14 @@ For TODO lists:
             tools=self.agent.tools
         )
 
-    async def run(self, user_input: str, stream_output: bool = True) -> str:
+    async def run(
+        self,
+        user_input: str,
+        stream_output: bool = True,
+        *,
+        enable_tracing: bool = False,
+        trace_dir: str | None = None,
+    ) -> str:
         """
         Run the agent with the given user input.
         
@@ -266,12 +273,18 @@ For TODO lists:
         
         # Run the agent
         if stream_output:
-            out = await self._run_streamed(user_input)
+            out = await self._run_streamed(
+                user_input,
+                enable_tracing=enable_tracing,
+                trace_dir=trace_dir,
+            )
         else:
             res = await Runner.run(
                 starting_agent=self.agent,
                 input=user_input,
                 context=self.context,
+                enable_tracing=enable_tracing,
+                trace_dir=trace_dir,
             )
             out = res.final_output
         
@@ -480,7 +493,13 @@ For TODO lists:
         # Log fallback results
         logger.debug("Fallback architecture entity extraction complete")
     
-    async def _run_streamed(self, user_input: str) -> str:
+    async def _run_streamed(
+        self,
+        user_input: str,
+        *,
+        enable_tracing: bool = False,
+        trace_dir: str | None = None,
+    ) -> str:
         """
         Run the agent with streamed output.
         
@@ -500,6 +519,8 @@ For TODO lists:
             input=user_input,
             max_turns=999,  # Increased for complex tasks
             context=self.context,
+            enable_tracing=enable_tracing,
+            trace_dir=trace_dir,
         )
         
         # Use the shared stream event handler 

--- a/The_Agents/WebBrowserAgent.py
+++ b/The_Agents/WebBrowserAgent.py
@@ -70,26 +70,47 @@ class WebBrowserAgent:
             tools=self.agent.tools,
         )
 
-    async def _run_streamed(self, user_input: str) -> str:
+    async def _run_streamed(
+        self,
+        user_input: str,
+        *,
+        enable_tracing: bool = False,
+        trace_dir: str | None = None,
+    ) -> str:
         result = Runner.run_streamed(
             starting_agent=self.agent,
             input=user_input,
             max_turns=50,
             context=self.context,
+            enable_tracing=enable_tracing,
+            trace_dir=trace_dir,
         )
         output = await handle_stream_events(result.stream_events())
         return output
 
-    async def run(self, user_input: str, stream_output: bool = True) -> str:
+    async def run(
+        self,
+        user_input: str,
+        stream_output: bool = True,
+        *,
+        enable_tracing: bool = False,
+        trace_dir: str | None = None,
+    ) -> str:
         self._prepare_context_for_agent()
         self.context.add_chat_message("user", user_input)
         if stream_output:
-            final = await self._run_streamed(user_input)
+            final = await self._run_streamed(
+                user_input,
+                enable_tracing=enable_tracing,
+                trace_dir=trace_dir,
+            )
         else:
             res = await Runner.run(
                 starting_agent=self.agent,
                 input=user_input,
                 context=self.context,
+                enable_tracing=enable_tracing,
+                trace_dir=trace_dir,
             )
             final = res.final_output
         self.context.add_chat_message("assistant", final)

--- a/main.py
+++ b/main.py
@@ -55,7 +55,7 @@ class AgentMode:
     ARCHITECT = "architect"
     BROWSER = "browser"
 
-async def main():
+async def main(*, enable_tracing: bool = False, trace_dir: str = "traces"):
     """Main function to run the dual-agent system with mode switching support."""
     # Initialize spaCy model at startup
     print(f"{YELLOW}Initializing spaCy model (this may take a moment)...{RESET}")
@@ -328,7 +328,12 @@ exit/quit   - Exit the program
                 # Get current agent and run 
                 current_agent = get_current_agent()
                 print(f"{BLUE}Processing with Architect Agent...{RESET}")
-                await current_agent.run(modified_query, stream_output=True)
+                await current_agent.run(
+                    modified_query,
+                    stream_output=True,
+                    enable_tracing=enable_tracing,
+                    trace_dir=trace_dir,
+                )
                 
                 # Save context after interaction
                 await current_agent.save_context()
@@ -361,7 +366,12 @@ exit/quit   - Exit the program
                 # Get current agent and run
                 current_agent = get_current_agent()
                 print(f"{BLUE}Processing with Architect Agent...{RESET}")
-                await current_agent.run(modified_query, stream_output=True)
+                await current_agent.run(
+                    modified_query,
+                    stream_output=True,
+                    enable_tracing=enable_tracing,
+                    trace_dir=trace_dir,
+                )
                 
                 # Save context after interaction
                 await current_agent.save_context()
@@ -446,7 +456,12 @@ exit/quit   - Exit the program
             print(f"{mode_color}Processing with {agent_name}...{RESET}")
             
             # Run the agent with streaming output
-            result = await current_agent.run(query, stream_output=True)
+            result = await current_agent.run(
+                query,
+                stream_output=True,
+                enable_tracing=enable_tracing,
+                trace_dir=trace_dir,
+            )
             # Since output is streamed, we don't need to print the result again
             
             # Save context after each interaction
@@ -456,4 +471,19 @@ exit/quit   - Exit the program
             print(f"\n{RED}Error running agent: {e}{RESET}\n")
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the multi-agent REPL")
+    parser.add_argument(
+        "--trace",
+        action="store_true",
+        help="Enable Agents SDK tracing",
+    )
+    parser.add_argument(
+        "--trace-dir",
+        default="traces",
+        help="Directory to store trace files",
+    )
+    args = parser.parse_args()
+
+    asyncio.run(main(enable_tracing=args.trace, trace_dir=args.trace_dir))


### PR DESCRIPTION
## Summary
- make tracing optional via `--trace` on the CLI
- pass `enable_tracing` and `trace_dir` to agent runs
- document how to enable tracing

## Testing
- `python -m py_compile The_Agents/SingleAgent.py The_Agents/ArchitectAgent.py The_Agents/WebBrowserAgent.py main.py`
- `pytest -q` *(fails: command not found)*
- `python spacy_test.py` *(fails: ModuleNotFoundError: No module named 'agents')*