### PR TITLE
Add MCP server integration

### DIFF
--- a/The_Agents/ArchitectAgent.py
+++ b/The_Agents/ArchitectAgent.py
@@ -86,7 +86,13 @@ class ArchitectAgent:
     for analyzing and suggesting improvements to project structure and design.
     """
     
-    def __init__(self, openai_client=None, context: EnhancedContextData | None = None, context_path: str = "architect_context.json"):
+    def __init__(
+        self,
+        openai_client=None,
+        context: EnhancedContextData | None = None,
+        context_path: str = "architect_context.json",
+        mcp_servers: list | None = None,
+    ):
         """
         Initialize the architect agent with default configuration.
         
@@ -96,6 +102,7 @@ class ArchitectAgent:
         self.openai_client = openai_client
         self.context_path = context_path
         self.instructions = self._get_default_instructions()
+        self.mcp_servers = mcp_servers
         
         # Create agent
         self.agent = Agent[EnhancedContextData](
@@ -115,7 +122,8 @@ class ArchitectAgent:
                 add_manual_context,
                 run_command,  # Added run_command tool
                 write_file
-            ]
+            ],
+            mcp_servers=self.mcp_servers,
         )
 
         logger.debug("ArchitectAgent initialized")
@@ -236,7 +244,8 @@ For TODO lists:
             name="ArchitectAgent",
             model="gpt-4.1",
             instructions=instr,
-            tools=self.agent.tools
+            tools=self.agent.tools,
+            mcp_servers=self.mcp_servers,
         )
 
     async def run(

--- a/The_Agents/SearchAgent.py
+++ b/The_Agents/SearchAgent.py
@@ -36,9 +36,15 @@ CONTEXT_FILE_PATH = os.path.join(os.path.expanduser("~"), ".searchagent_context.
 class SearchAgent:
     """Agent responsible for web searches."""
 
-    def __init__(self, context: EnhancedContextData | None = None, context_path: str = CONTEXT_FILE_PATH) -> None:
+    def __init__(
+        self,
+        context: EnhancedContextData | None = None,
+        context_path: str = CONTEXT_FILE_PATH,
+        mcp_servers: list | None = None,
+    ) -> None:
         cwd = os.getcwd()
         self.context_path = context_path
+        self.mcp_servers = mcp_servers
         self.context = context or EnhancedContextData(
             working_directory=cwd,
             project_name=os.path.basename(cwd),
@@ -58,6 +64,7 @@ class SearchAgent:
                 get_context_response,
                 add_manual_context,
             ],
+            mcp_servers=self.mcp_servers,
         )
 
     def to_tool(self):
@@ -96,6 +103,7 @@ class SearchAgent:
             model="gpt-4.1",
             instructions=instr,
             tools=self.agent.tools,
+            mcp_servers=self.mcp_servers,
         )
 
     async def _run_streamed(self, user_input: str) -> str:

--- a/The_Agents/SingleAgent.py
+++ b/The_Agents/SingleAgent.py
@@ -311,6 +311,7 @@ class SingleAgent:
         browser_agent=None,
         search_agent=None,
         architect_agent=None,
+        mcp_servers: list | None = None,
     ):
         # ensure we always have a context attribute before async loading
         cwd = os.getcwd()
@@ -318,6 +319,7 @@ class SingleAgent:
         self.browser_agent = browser_agent
         self.search_agent = search_agent
         self.architect_agent = architect_agent
+        self.mcp_servers = mcp_servers
         self.context = context or EnhancedContextData(
             working_directory=cwd,
             project_name=os.path.basename(cwd),
@@ -373,7 +375,8 @@ class SingleAgent:
                 get_context_response,
                 add_manual_context
             ],
-            handoffs=handoffs
+            handoffs=handoffs,
+            mcp_servers=self.mcp_servers,
         )
 
         if self.browser_agent is not None:
@@ -464,6 +467,7 @@ class SingleAgent:
             instructions=instr,
             tools=self.agent.tools,
             handoffs=handoffs,
+            mcp_servers=self.mcp_servers,
         )
 
     async def run(

--- a/The_Agents/WebBrowserAgent.py
+++ b/The_Agents/WebBrowserAgent.py
@@ -22,9 +22,15 @@ When exposed as a tool to other agents, use the name `web_browser_agent`.
 CONTEXT_FILE_PATH = os.path.join(os.path.expanduser("~"), ".webbrowser_context.json")
 
 class WebBrowserAgent:
-    def __init__(self, context: EnhancedContextData | None = None, context_path: str = CONTEXT_FILE_PATH):
+    def __init__(
+        self,
+        context: EnhancedContextData | None = None,
+        context_path: str = CONTEXT_FILE_PATH,
+        mcp_servers: list | None = None,
+    ):
         cwd = os.getcwd()
         self.context_path = context_path
+        self.mcp_servers = mcp_servers
         self.context = context or EnhancedContextData(
             working_directory=cwd,
             project_name=os.path.basename(cwd),
@@ -38,6 +44,7 @@ class WebBrowserAgent:
             model="gpt-4.1",
             instructions=BROWSER_INSTRUCTIONS,
             tools=[fetch_url, search_web, get_context, get_context_response, add_manual_context],
+            mcp_servers=self.mcp_servers,
         )
 
     def to_tool(self):
@@ -76,6 +83,7 @@ class WebBrowserAgent:
             model="gpt-4.1",
             instructions=instr,
             tools=self.agent.tools,
+            mcp_servers=self.mcp_servers,
         )
 
     async def _run_streamed(

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -49,6 +49,7 @@ class Agent(Generic[T]):
     instructions: str = ""
     tools: list | None = None
     handoffs: list | None = None
+    mcp_servers: list | None = None
     model_settings: object | None = None
 
     @classmethod
@@ -60,6 +61,8 @@ class Agent(Generic[T]):
             self.tools = []
         if self.handoffs is None:
             self.handoffs = []
+        if self.mcp_servers is None:
+            self.mcp_servers = []
 
     async def respond(self, input: str, context=None):
         return f"{self.name} response: {input}"

--- a/agents/mcp/__init__.py
+++ b/agents/mcp/__init__.py
@@ -1,0 +1,35 @@
+class MCPServerBase:
+    """Minimal stub for MCP server."""
+    def __init__(self, *, cache_tools_list=False):
+        self.cache_tools_list = cache_tools_list
+        self._tools_cache = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def list_tools(self):
+        if self.cache_tools_list and self._tools_cache is not None:
+            return self._tools_cache
+        return []
+
+    async def invalidate_tools_cache(self):
+        self._tools_cache = None
+
+    async def call_tool(self, name, *args, **kwargs):
+        return None
+
+
+class MCPServerStdio(MCPServerBase):
+    def __init__(self, *, params=None, cache_tools_list=False):
+        super().__init__(cache_tools_list=cache_tools_list)
+        self.params = params or {}
+
+
+class MCPServerSse(MCPServerBase):
+    def __init__(self, *, url='', cache_tools_list=False):
+        super().__init__(cache_tools_list=cache_tools_list)
+        self.url = url
+


### PR DESCRIPTION
## Summary
- add stub `MCPServerStdio` and `MCPServerSse`
- let `Agent` keep track of `mcp_servers`
- expose `mcp_servers` in all agent classes
- optionally start MCP server from `main.py`
- add CLI flags to configure MCP

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest')*