### PR TITLE
Fix asyncio run_streamed issue

### DIFF
--- a/The_Agents/ArchitectAgent.py
+++ b/The_Agents/ArchitectAgent.py
@@ -532,7 +532,7 @@ For TODO lists:
         print(f"{CYAN}Starting architect agent...{RESET}")
         
         # Run the agent with streaming
-        result = Runner.run_streamed(
+        result = await Runner.run_streamed(
             starting_agent=self.agent,
             input=user_input,
             max_turns=999,  # Increased for complex tasks

--- a/The_Agents/SearchAgent.py
+++ b/The_Agents/SearchAgent.py
@@ -107,7 +107,7 @@ class SearchAgent:
         )
 
     async def _run_streamed(self, user_input: str) -> str:
-        result = Runner.run_streamed(
+        result = await Runner.run_streamed(
             starting_agent=self.agent,
             input=user_input,
             max_turns=50,

--- a/The_Agents/SingleAgent.py
+++ b/The_Agents/SingleAgent.py
@@ -691,7 +691,7 @@ class SingleAgent:
         print(f"{CYAN}Starting agent...{RESET}")
         
         # Run the agent with streaming
-        result = Runner.run_streamed(
+        result = await Runner.run_streamed(
             starting_agent=self.agent,
             input=user_input,
             max_turns=999,  # Increased for complex tasks

--- a/The_Agents/WebBrowserAgent.py
+++ b/The_Agents/WebBrowserAgent.py
@@ -93,7 +93,7 @@ class WebBrowserAgent:
         enable_tracing: bool = False,
         trace_dir: str | None = None,
     ) -> str:
-        result = Runner.run_streamed(
+        result = await Runner.run_streamed(
             starting_agent=self.agent,
             input=user_input,
             max_turns=50,

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -82,16 +82,18 @@ class Runner:
         return SimpleNamespace(final_output=output)
 
     @staticmethod
-    def run_streamed(*args, **kwargs):
+    async def run_streamed(*args, **kwargs):
+        """Asynchronously run an agent and return a dummy streamed result."""
         class Dummy:
             def __init__(self, output):
                 self.final_output = output
+
             async def stream_events(self):
                 if False:
                     yield None
-        loop = asyncio.get_event_loop()
-        output = loop.run_until_complete(Runner.run(*args, **kwargs)).final_output
-        return Dummy(output)
+
+        result = await Runner.run(*args, **kwargs)
+        return Dummy(result.final_output)
 
 
 class WebSearchTool:


### PR DESCRIPTION
## Summary
- make `Runner.run_streamed` async instead of running a nested loop
- await `Runner.run_streamed` in all agent `_run_streamed` helpers

## Testing
- `pytest -q` *(fails: `pytest: command not found`)*
- `python main.py` *(fails: `ModuleNotFoundError: No module named 'prompt_toolkit'`)*