### PR TITLE
Add requirements with spaCy model

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+openai
+openai-agents
+prompt_toolkit
+tiktoken
+pydantic
+spacy
+en-core-web-lg
+networkx
+toml
+typing_extensions
+ruff
+pylint
+pyright


### PR DESCRIPTION
## Summary
- add initial `requirements.txt`

## Testing
- `ruff check .` *(fails: Failed to parse pyproject.toml)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_683d9302cb2c8329812df6da72fe6c6a