### PR TITLE
Increase default context window to 400k tokens

### DIFF
--- a/The_Agents/ArchitectAgent.py
+++ b/The_Agents/ArchitectAgent.py
@@ -49,14 +49,15 @@ except ImportError:
             self.delta = delta
 
 from agents import (
-    Agent, 
-    Runner, 
+    Agent,
+    Runner,
     ItemHelpers,
-    RunItemStreamEvent, 
+    RunItemStreamEvent,
     RawResponsesStreamEvent,
     AgentUpdatedStreamEvent,
     RunContextWrapper
 )
+from agents.model_settings import ModelSettings
 
 
 # Import architect tools
@@ -112,8 +113,9 @@ class ArchitectAgent:
                 read_directory,
                 add_manual_context,
                 run_command,  # Added run_command tool
-                write_file  
-            ]
+                write_file
+            ],
+            model_settings=ModelSettings(max_tokens=400_000)
         )
         
         logger.debug("ArchitectAgent initialized")
@@ -121,14 +123,15 @@ class ArchitectAgent:
         cwd = os.getcwd()
         self.context = EnhancedContextData(
             working_directory=cwd,
-            project_name=os.path.basename(cwd)
+            project_name=os.path.basename(cwd),
+            max_tokens=400_000
         )
         
     async def _load_context(self):
         """
         Load context data from persistent storage if available.
         """
-        self.context = EnhancedContextData()  # Initialize empty context
+        self.context = EnhancedContextData(max_tokens=400_000)  # Initialize empty context
         
         # Try to load persisted context 
         context_file = "architect_context.json"
@@ -232,7 +235,8 @@ For TODO lists:
             name="ArchitectAgent",
             model="gpt-5",
             instructions=instr,
-            tools=self.agent.tools
+            tools=self.agent.tools,
+            model_settings=ModelSettings(max_tokens=400_000)
         )
 
     async def run(self, user_input: str, stream_output: bool = True) -> str:

--- a/The_Agents/MCPEnhancedSingleAgent.py
+++ b/The_Agents/MCPEnhancedSingleAgent.py
@@ -18,6 +18,7 @@ from agents.mcp.server import MCPServerStdio, MCPServerSse
 
 # Your existing imports
 from agents import Agent, Runner, ItemHelpers, function_tool
+from agents.model_settings import ModelSettings
 from The_Agents.context_data import EnhancedContextData
 from Tools.singleagent_tools import (
     run_ruff, run_pylint, run_pyright, run_command,
@@ -80,6 +81,7 @@ class MCPEnhancedSingleAgent:
             project_name=os.path.basename(cwd),
             project_info=discover_project_info(cwd),
             current_file=None,
+            max_tokens=400_000,
         )
         
         # Store working directories for multi-project support
@@ -167,7 +169,8 @@ class MCPEnhancedSingleAgent:
                 model="gpt-4o",  # FIXED: Use proper model name
                 instructions=self._get_enhanced_instructions(),
                 tools=self.base_tools,
-                mcp_servers=self.mcp_servers
+                mcp_servers=self.mcp_servers,
+                model_settings=ModelSettings(max_tokens=400_000)
             )
             
             logger.info(f"Agent created with {len(self.base_tools)} custom tools and {len(self.mcp_servers)} MCP servers")

--- a/The_Agents/MCPEnhancedSingleAgent_fixed.py
+++ b/The_Agents/MCPEnhancedSingleAgent_fixed.py
@@ -18,6 +18,7 @@ from agents.mcp.server import MCPServerStdio, MCPServerSse
 
 # Your existing imports
 from agents import Agent, Runner, ItemHelpers, function_tool
+from agents.model_settings import ModelSettings
 from The_Agents.context_data import EnhancedContextData
 from Tools.singleagent_tools import (
     run_ruff, run_pylint, run_pyright, run_command,
@@ -80,6 +81,7 @@ class MCPEnhancedSingleAgent:
             project_name=os.path.basename(cwd),
             project_info=discover_project_info(cwd),
             current_file=None,
+            max_tokens=400_000,
         )
         
         # Store working directories for multi-project support
@@ -154,7 +156,8 @@ class MCPEnhancedSingleAgent:
                 model="gpt-5",  # FIXED: Use correct model name
                 instructions=self._get_enhanced_instructions(),
                 tools=self.base_tools,
-                mcp_servers=self.mcp_servers
+                mcp_servers=self.mcp_servers,
+                model_settings=ModelSettings(max_tokens=400_000)
             )
             
             logger.info(f"Agent created with {len(self.base_tools)} custom tools and {len(self.mcp_servers)} MCP servers")

--- a/The_Agents/SingleAgent.py
+++ b/The_Agents/SingleAgent.py
@@ -308,6 +308,7 @@ class SingleAgent:
             project_name=os.path.basename(cwd),
             project_info=discover_project_info(cwd),
             current_file=None,
+            max_tokens=400_000,
         )
         """Initialize the code assistant agent with all required tools and enhanced context."""
         # Attempt to load existing context or create new one
@@ -330,7 +331,7 @@ class SingleAgent:
         self.agent = Agent[EnhancedContextData](
             name="CodeAssistant",
             model="gpt-5",
-            model_settings=ModelSettings(temperature=0.0),  # Correct way to set temperature
+            model_settings=ModelSettings(temperature=0.0, max_tokens=400_000),  # Support 400k context
             instructions=AGENT_INSTRUCTIONS,
             tools=[
                 run_ruff,
@@ -385,6 +386,7 @@ class SingleAgent:
                 project_name=os.path.basename(cwd),
                 project_info=discover_project_info(cwd),
                 current_file=None,
+                max_tokens=400_000,
             )
     
     async def save_context(self):
@@ -422,7 +424,8 @@ class SingleAgent:
             name="CodeAssistant",
             model="gpt-5",           # ← use the same model string as in __init__
             instructions=instr,
-            tools=self.agent.tools
+            tools=self.agent.tools,
+            model_settings=ModelSettings(temperature=0.0, max_tokens=400_000)
         )
 
     async def run(self, user_input: str, stream_output: bool = True):


### PR DESCRIPTION
## Summary
- Raise `EnhancedContextData` default context limit to 400k tokens and enforce it when loading legacy contexts
- Pass the new limit to all agents and configure `ModelSettings` for a 400k-token window
- Allow OpenAI summarization calls to output up to 400k tokens

## Testing
- `pytest` *(fails: OSError: Can't find model 'en_core_web_lg')*
- `python -m spacy download en_core_web_lg` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b1fa99bf48329b37bee8cb03c0135