### PR TITLE
refactor: move stream event imports to module scope

### DIFF
--- a/utilities/tool_usage.py
+++ b/utilities/tool_usage.py
@@ -7,6 +7,8 @@ import asyncio
 import logging
 from typing import Any, Dict, Optional, Union, List, Callable, AsyncIterable
 
+from agents.stream_events import RunItemStreamEvent, RawResponsesStreamEvent, AgentUpdatedStreamEvent
+
 # Configure logger
 logger = logging.getLogger(__name__)
 
@@ -160,8 +162,6 @@ async def process_stream_event(event, context, item_helpers, output_text_buffer:
     Returns:
         Tuple of (updated_buffer, processed_output, consume_event)
     """
-    from agents.stream_events import RunItemStreamEvent, RawResponsesStreamEvent, AgentUpdatedStreamEvent
-    
     processed_output = ""
     consume_event = False
     


### PR DESCRIPTION
## Summary
- import stream event classes at module level in `tool_usage`
- remove redundant stream event import inside `process_stream_event`

## Testing
- `pytest` *(fails: Can't find model 'en_core_web_lg')*


------
https://chatgpt.com/codex/tasks/task_e_689b603231e0832986ac6a6dc7edd98e