### PR TITLE
Avoid costly JSON debug logging

### DIFF
--- a/The_Agents/ArchitectAgent.py
+++ b/The_Agents/ArchitectAgent.py
@@ -255,7 +255,8 @@ For TODO lists:
             await self._load_context()
         
         # Log start of run
-        logger.debug(json.dumps({"event": "run_start", "user_input": user_input}))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("run_start user_input=%s", user_input)
         
         # Process input for potential entities
         await self._extract_entities_from_input(user_input)
@@ -291,12 +292,13 @@ For TODO lists:
         await self.save_context()
         
         # Log end of run
-        logger.debug(json.dumps({
-            "event": "run_end", 
-            "output": out,
-            "chat_history_length": len(self.context.chat_messages),
-            "token_count": self.context.token_count
-        }))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "run_end output=%s chat_history_length=%d token_count=%d",
+                out,
+                len(self.context.chat_messages),
+                self.context.token_count,
+            )
         
         return out
     
@@ -500,7 +502,8 @@ For TODO lists:
             The final output from the agent
         """
         # Log start of streamed run
-        logger.debug(json.dumps({"event": "_run_streamed_start", "user_input": user_input}))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("_run_streamed_start user_input=%s", user_input)
         print(f"{CYAN}Starting architect agent...{RESET}")
         
         # Run the agent with streaming
@@ -520,10 +523,8 @@ For TODO lists:
         )
         
         # Log end of streamed run
-        logger.debug(json.dumps({
-            "event": "_run_streamed_end",
-            "output_length": len(output_text_buffer)
-        }))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("_run_streamed_end output_length=%d", len(output_text_buffer))
         
         return output_text_buffer
 

--- a/The_Agents/SingleAgent.py
+++ b/The_Agents/SingleAgent.py
@@ -626,7 +626,8 @@ class SingleAgent:
             The final output from the agent
         """
         # Log start of streamed run
-        logger.debug(json.dumps({"event": "_run_streamed_start", "user_input": user_input}))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("_run_streamed_start user_input=%s", user_input)
         print(f"{CYAN}Starting agent...{RESET}")
         
         # Run the agent with streaming
@@ -655,11 +656,12 @@ class SingleAgent:
         # Update context with token count from response
         self.context.update_token_count(response_tokens)
         
-        logger.debug(json.dumps({
-            "event": "_run_streamed_end", 
-            "final_output": final,
-            "token_count": self.context.token_count
-        }))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "_run_streamed_end final_output=%s token_count=%d",
+                final,
+                self.context.token_count,
+            )
         
         return final
 
@@ -674,7 +676,8 @@ class SingleAgent:
     def clear_chat_history(self) -> None:
         """Clear the chat history."""
         self.context.clear_chat_history()
-        logger.debug(json.dumps({"event": "chat_history_cleared"}))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("chat_history_cleared")
 
 async def main():
     """Main function to run the SingleAgent REPL."""

--- a/Tools/architect_tools.py
+++ b/Tools/architect_tools.py
@@ -95,7 +95,8 @@ async def write_file(wrapper: RunContextWrapper[EnhancedContextData], params: Wr
     """
     # Compute write mode, defaulting to 'w' if not provided
     mode = params.mode if params.mode is not None else "w"
-    logger.debug(json.dumps({"tool": "write_file", "params": {"file_path": params.file_path, "mode": mode}}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("write_file file_path=%s mode=%s", params.file_path, mode)
     
     try:
         # Ensure the directory exists
@@ -111,11 +112,13 @@ async def write_file(wrapper: RunContextWrapper[EnhancedContextData], params: Wr
         track_file_entity(wrapper.context, params.file_path, params.content)
         
         file_size = os.path.getsize(params.file_path)
-        logger.debug(json.dumps({"tool": "write_file", "output": f"File written: {params.file_path}, size: {file_size} bytes"}))
-        
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("write_file output=File written: %s, size: %d bytes", params.file_path, file_size)
+
         return f"Successfully wrote {file_size} bytes to {params.file_path}"
     except Exception as e:
-        logger.debug(json.dumps({"tool": "write_file", "error": str(e)}))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("write_file error=%s", e)
         return f"Error writing to file: {str(e)}"
 
 @function_tool
@@ -136,7 +139,8 @@ async def analyze_ast(wrapper: RunContextWrapper[EnhancedContextData], params: A
     Returns:
         Dictionary containing the requested analysis information
     """
-    logger.debug(json.dumps({"tool": "analyze_ast", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("analyze_ast params=%s", params.model_dump())
     
     try:
         # Read the file and parse the AST
@@ -251,7 +255,8 @@ async def analyze_ast(wrapper: RunContextWrapper[EnhancedContextData], params: A
                         dependencies.add(node.module.split('.')[0])
             result['dependencies'] = list(dependencies)
         
-        logger.debug(json.dumps({"tool": "analyze_ast", "result_size": len(json.dumps(result))}))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("analyze_ast result_size=%d", len(json.dumps(result)))
         return result
     except Exception as e:
         logger.error(f"Error in analyze_ast: {str(e)}", exc_info=True)
@@ -275,7 +280,8 @@ async def analyze_project_structure(wrapper: RunContextWrapper[EnhancedContextDa
     Returns:
         Dictionary containing project structure information
     """
-    logger.debug(json.dumps({"tool": "analyze_project_structure", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("analyze_project_structure params=%s", params.model_dump())
     
     try:
         import fnmatch
@@ -384,7 +390,8 @@ async def analyze_project_structure(wrapper: RunContextWrapper[EnhancedContextDa
             metadata={"file_count": file_count, "dir_count": dir_count}
         )
         
-        logger.debug(json.dumps({"tool": "analyze_project_structure", "result_size": len(json.dumps(result))}))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("analyze_project_structure result_size=%d", len(json.dumps(result)))
         return result
     
     except Exception as e:
@@ -409,7 +416,8 @@ async def generate_todo_list(wrapper: RunContextWrapper[EnhancedContextData], pa
     Returns:
         Dictionary containing structured TODO list with tasks, priorities, and dependencies
     """
-    logger.debug(json.dumps({"tool": "generate_todo_list", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("generate_todo_list params=%s", params.model_dump())
     
     try:
         # Initialize the result structure
@@ -578,7 +586,8 @@ async def generate_todo_list(wrapper: RunContextWrapper[EnhancedContextData], pa
         else:
             result["suggested_approach"] = "Modular implementation with iterative development cycles"
         
-        logger.debug(json.dumps({"tool": "generate_todo_list", "result_size": len(json.dumps(result))}))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("generate_todo_list result_size=%d", len(json.dumps(result)))
         return result
     
     except Exception as e:
@@ -601,7 +610,8 @@ async def analyze_dependencies(wrapper: RunContextWrapper[EnhancedContextData], 
     Returns:
         Dictionary containing dependency information and graph representation
     """
-    logger.debug(json.dumps({"tool": "analyze_dependencies", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("analyze_dependencies params=%s", params.model_dump())
     
     try:
         import glob
@@ -691,7 +701,8 @@ async def analyze_dependencies(wrapper: RunContextWrapper[EnhancedContextData], 
             metadata={"module_count": len(module_map), "dependency_count": G.number_of_edges()}
         )
         
-        logger.debug(json.dumps({"tool": "analyze_dependencies", "result_size": len(json.dumps(result))}))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("analyze_dependencies result_size=%d", len(json.dumps(result)))
         return result
     
     except Exception as e:
@@ -714,7 +725,8 @@ async def detect_code_patterns(wrapper: RunContextWrapper[EnhancedContextData], 
     Returns:
         Dictionary containing detected patterns and their instances
     """
-    logger.debug(json.dumps({"tool": "detect_code_patterns", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("detect_code_patterns params=%s", params.model_dump())
     
     try:
         # Read and parse the file
@@ -890,7 +902,8 @@ async def detect_code_patterns(wrapper: RunContextWrapper[EnhancedContextData], 
             "anti_patterns_found": sum(1 for p in anti_patterns.values() if p["instances"])
         }
         
-        logger.debug(json.dumps({"tool": "detect_code_patterns", "result_size": len(json.dumps(result))}))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("detect_code_patterns result_size=%d", len(json.dumps(result)))
         return result
     
     except Exception as e:
@@ -915,7 +928,8 @@ async def read_directory(wrapper: RunContextWrapper[EnhancedContextData], params
     Returns:
         Dictionary containing directory structure and statistics
     """
-    logger.debug(json.dumps({"tool": "read_directory", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("read_directory params=%s", params.model_dump())
     
     try:
         import fnmatch
@@ -1060,7 +1074,8 @@ async def read_directory(wrapper: RunContextWrapper[EnhancedContextData], params
             "base_directory": directory_path
         }
         
-        logger.debug(json.dumps({"tool": "read_directory", "result_size": len(json.dumps(result))}))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("read_directory result_size=%d", len(json.dumps(result)))
         return result
     
     except Exception as e:

--- a/Tools/shared_tools.py
+++ b/Tools/shared_tools.py
@@ -208,7 +208,8 @@ async def add_manual_context(wrapper: RunContextWrapper[EnhancedContextData], pa
     Returns:
         Summary of the added context
     """
-    logger.debug(json.dumps({"tool": "add_manual_context", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("add_manual_context params=%s", params.model_dump())
     
     try:
         # Verify file exists
@@ -254,7 +255,8 @@ async def run_command(wrapper: RunContextWrapper[EnhancedContextData], params: R
     Returns:
         Command output (stdout and stderr)
     """
-    logger.debug(json.dumps({"tool": "run_command", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("run_command params=%s", params.model_dump())
     working_dir = params.working_dir if params.working_dir is not None else os.getcwd()
     try:
         proc = await asyncio.create_subprocess_shell(
@@ -269,13 +271,15 @@ async def run_command(wrapper: RunContextWrapper[EnhancedContextData], params: R
             output += f"\nSTDERR:\n{stderr.decode()}"
         if not output:
             output = "Command executed successfully with no output."
-        
+
         # Track command entity in context
         track_command_entity(wrapper.context, params.command, output)
-        logger.debug(json.dumps({"tool": "run_command", "output": output}))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("run_command output=%s", output)
         return output
     except Exception as e:
-        logger.debug(json.dumps({"tool": "run_command", "error": str(e)}))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("run_command error=%s", e)
         return f"Error executing command: {str(e)}"
 
 @function_tool
@@ -292,7 +296,8 @@ async def read_file(wrapper: RunContextWrapper[EnhancedContextData], params: Fil
     Returns:
         Dictionary containing file content and metadata
     """
-    logger.debug(json.dumps({"tool": "read_file", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("read_file params=%s", params.model_dump())
     
     try:
         # Normalize path - handle relative paths automatically
@@ -350,8 +355,9 @@ async def read_file(wrapper: RunContextWrapper[EnhancedContextData], params: Fil
             "content": content,
             "metadata": metadata
         }
-        
-        logger.debug(json.dumps({"tool": "read_file", "result_size": len(content)}))
+
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("read_file result_size=%d", len(content))
         return result
     
     except Exception as e:
@@ -369,7 +375,8 @@ async def get_context(wrapper: RunContextWrapper[EnhancedContextData], params: G
     Returns:
         String summary of current context
     """
-    logger.debug(json.dumps({"tool": "get_context", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("get_context params=%s", params.model_dump())
     context = wrapper.context
     info = [
         f"Working directory: {context.working_directory}",
@@ -422,7 +429,8 @@ async def get_context(wrapper: RunContextWrapper[EnhancedContextData], params: G
             info.append(summary)
 
     result = "\n".join(info)
-    logger.debug(json.dumps({"tool": "get_context", "output_length": len(result)}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("get_context output_length=%d", len(result))
     return result
 
 # Cross-agent communication tools
@@ -443,7 +451,8 @@ async def request_architecture_review(wrapper: RunContextWrapper[EnhancedContext
     Returns:
         Confirmation message with task ID
     """
-    logger.debug(json.dumps({"tool": "request_architecture_review", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("request_architecture_review params=%s", params.model_dump())
     
     # Get the shared context manager from metadata
     shared_manager = wrapper.context.metadata.get("shared_manager")
@@ -481,7 +490,8 @@ async def request_implementation(wrapper: RunContextWrapper[EnhancedContextData]
     Returns:
         Confirmation message with task ID
     """
-    logger.debug(json.dumps({"tool": "request_implementation", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("request_implementation params=%s", params.model_dump())
     
     # Get the shared context manager from metadata
     shared_manager = wrapper.context.metadata.get("shared_manager")
@@ -523,7 +533,8 @@ async def share_insight(wrapper: RunContextWrapper[EnhancedContextData], params:
     Returns:
         Confirmation message with insight ID
     """
-    logger.debug(json.dumps({"tool": "share_insight", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("share_insight params=%s", params.model_dump())
     
     # Get the shared context manager from metadata
     shared_manager = wrapper.context.metadata.get("shared_manager")
@@ -561,7 +572,8 @@ async def record_architectural_decision(wrapper: RunContextWrapper[EnhancedConte
     Returns:
         Confirmation message with decision ID
     """
-    logger.debug(json.dumps({"tool": "record_architectural_decision", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("record_architectural_decision params=%s", params.model_dump())
     
     # Get the shared context manager from metadata
     shared_manager = wrapper.context.metadata.get("shared_manager")
@@ -592,7 +604,8 @@ async def get_collaboration_status(wrapper: RunContextWrapper[EnhancedContextDat
     Returns:
         Collaboration status summary
     """
-    logger.debug(json.dumps({"tool": "get_collaboration_status", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("get_collaboration_status params=%s", params.model_dump())
     
     # Get the shared context manager from metadata
     shared_manager = wrapper.context.metadata.get("shared_manager")
@@ -663,7 +676,8 @@ async def start_feature_workflow(wrapper: RunContextWrapper[EnhancedContextData]
     Returns:
         Workflow ID and confirmation message
     """
-    logger.debug(json.dumps({"tool": "start_feature_workflow", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("start_feature_workflow params=%s", params.model_dump())
     
     # Get the workflow orchestrator from metadata
     orchestrator = wrapper.context.metadata.get("workflow_orchestrator")
@@ -693,7 +707,8 @@ async def start_bugfix_workflow(wrapper: RunContextWrapper[EnhancedContextData],
     Returns:
         Workflow ID and confirmation message
     """
-    logger.debug(json.dumps({"tool": "start_bugfix_workflow", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("start_bugfix_workflow params=%s", params.model_dump())
     
     # Get the workflow orchestrator from metadata
     orchestrator = wrapper.context.metadata.get("workflow_orchestrator")
@@ -723,7 +738,8 @@ async def start_refactor_workflow(wrapper: RunContextWrapper[EnhancedContextData
     Returns:
         Workflow ID and confirmation message
     """
-    logger.debug(json.dumps({"tool": "start_refactor_workflow", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("start_refactor_workflow params=%s", params.model_dump())
     
     # Get the workflow orchestrator from metadata
     orchestrator = wrapper.context.metadata.get("workflow_orchestrator")
@@ -752,7 +768,8 @@ async def get_workflow_status(wrapper: RunContextWrapper[EnhancedContextData], p
     Returns:
         Detailed workflow status
     """
-    logger.debug(json.dumps({"tool": "get_workflow_status", "params": params.model_dump()}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("get_workflow_status params=%s", params.model_dump())
     
     # Get the workflow orchestrator from metadata
     orchestrator = wrapper.context.metadata.get("workflow_orchestrator")
@@ -804,7 +821,8 @@ async def list_active_workflows(wrapper: RunContextWrapper[EnhancedContextData])
     Returns:
         List of active workflows with their status
     """
-    logger.debug(json.dumps({"tool": "list_active_workflows"}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("list_active_workflows")
     
     # Get the workflow orchestrator from metadata
     orchestrator = wrapper.context.metadata.get("workflow_orchestrator")


### PR DESCRIPTION
## Summary
- Guard debug logs behind `logger.isEnabledFor(logging.DEBUG)` across tool and agent modules
- Replace `json.dumps` debug payloads with simple string messages to reduce overhead

## Testing
- `pytest` *(fails: Can't find model 'en_core_web_lg')*

------
https://chatgpt.com/codex/tasks/task_e_689b603749f08329acf76632c52c3896