### PR TITLE
feat: add file read caching

### DIFF
--- a/Tools/shared_tools.py
+++ b/Tools/shared_tools.py
@@ -33,6 +33,10 @@ shared_logger.propagate = False
 # alias shared_logger as logger for use in function implementations
 logger = shared_logger
 
+# Simple module-level cache for file reads keyed by absolute path
+# Each entry stores mtime, size, content, and metadata
+_file_cache: Dict[str, Dict[str, Any]] = {}
+
 # Shared utility functions for tracking entities in context
 def track_file_entity(ctx, file_path, content):
     """
@@ -211,31 +215,26 @@ async def add_manual_context(wrapper: RunContextWrapper[EnhancedContextData], pa
     logger.debug(json.dumps({"tool": "add_manual_context", "params": params.model_dump()}))
     
     try:
-        # Verify file exists
-        if not os.path.isfile(params.file_path):
-            return f"Error: File not found at {params.file_path}"
-            
-        # Read file content
-        with open(params.file_path, 'r', encoding='utf-8') as f:
-            content = f.read()
-            
+        # Use read_file to leverage caching and tracking
+        result = await read_file(wrapper, FileReadParams(file_path=params.file_path))
+        if "error" in result:
+            return f"Error: {result['error']}"
+
+        content = result["content"]
         if not content:
             return f"Error: Empty file at {params.file_path}"
-            
+
         # Add to context
         label = wrapper.context.add_manual_context(
             content=content,
             source=params.file_path,
             label=params.label
         )
-        
-        # Track as file entity as well
-        track_file_entity(wrapper.context, params.file_path, content)
-        
+
         # Return success message
         tokens = wrapper.context.count_tokens(content)
         return f"Successfully added context from {params.file_path} with label '{label}' ({tokens} tokens)"
-    
+
     except Exception as e:
         logger.error(f"Error adding manual context: {str(e)}", exc_info=True)
         return f"Error adding context: {str(e)}"
@@ -313,45 +312,55 @@ async def read_file(wrapper: RunContextWrapper[EnhancedContextData], params: Fil
         # Get file stats
         file_stats = os.stat(file_path)
         file_size = file_stats.st_size
-        
+
         # Check file size (limit to reasonable size to prevent resource issues)
         if file_size > 5 * 1024 * 1024:
             return {"error": f"File too large ({file_size / 1024 / 1024:.2f} MB). Maximum size is 5 MB."}
-        
-        # Read file with proper error handling
-        try:
-            with open(file_path, 'r', encoding='utf-8', errors='replace') as f:
-                content = f.read()
-        except UnicodeDecodeError:
-            return {"error": f"Could not decode file as text: {file_path}. This may be a binary file."}
-        except PermissionError:
-            return {"error": f"Permission denied when reading file: {file_path}"}
-        
-        # Get file extension
-        _, file_extension = os.path.splitext(file_path)
-        file_extension = file_extension.lower()
-        
-        # Track file in context
+
+        # Check cache: reuse content and metadata if unchanged
+        cached = False
+        cache_entry = _file_cache.get(file_path)
+        if cache_entry and cache_entry["mtime"] == file_stats.st_mtime and cache_entry["size"] == file_size:
+            content = cache_entry["content"]
+            metadata = cache_entry["metadata"]
+            cached = True
+        else:
+            # Read file with proper error handling
+            try:
+                with open(file_path, 'r', encoding='utf-8', errors='replace') as f:
+                    content = f.read()
+            except UnicodeDecodeError:
+                return {"error": f"Could not decode file as text: {file_path}. This may be a binary file."}
+            except PermissionError:
+                return {"error": f"Permission denied when reading file: {file_path}"}
+
+            # Get file extension
+            _, file_extension = os.path.splitext(file_path)
+            file_extension = file_extension.lower()
+
+            metadata = {
+                "file_path": file_path,
+                "file_name": os.path.basename(file_path),
+                "file_size": file_size,
+                "file_extension": file_extension,
+                "last_modified": datetime.fromtimestamp(file_stats.st_mtime).isoformat(),
+                "token_count": wrapper.context.count_tokens(content),
+                "line_count": content.count('\n') + 1
+            }
+
+            _file_cache[file_path] = {
+                "mtime": file_stats.st_mtime,
+                "size": file_size,
+                "content": content,
+                "metadata": metadata,
+            }
+
+        # Track file in context using content (cached or new)
         track_file_entity(wrapper.context, file_path, content)
-        
-        # Create metadata
-        metadata = {
-            "file_path": file_path,
-            "file_name": os.path.basename(file_path),
-            "file_size": file_size,
-            "file_extension": file_extension,
-            "last_modified": datetime.fromtimestamp(file_stats.st_mtime).isoformat(),
-            "token_count": wrapper.context.count_tokens(content),
-            "line_count": content.count('\n') + 1
-        }
-        
-        # Return result
-        result = {
-            "content": content,
-            "metadata": metadata
-        }
-        
-        logger.debug(json.dumps({"tool": "read_file", "result_size": len(content)}))
+
+        result = {"content": content, "metadata": metadata}
+
+        logger.debug(json.dumps({"tool": "read_file", "result_size": len(content), "cached": cached}))
         return result
     
     except Exception as e:

--- a/tests/test_read_file_cache.py
+++ b/tests/test_read_file_cache.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import asyncio
+from unittest.mock import patch
+
+# Ensure repository root is on sys.path for imports
+sys.path.append(os.getcwd())
+
+from agents import RunContextWrapper
+from The_Agents.context_data import EnhancedContextData
+from Tools.shared_tools import read_file, _file_cache
+import json
+
+
+def test_read_file_uses_cache(tmp_path):
+    _file_cache.clear()
+    file_path = tmp_path / "sample.txt"
+    file_path.write_text("hello")
+    wrapper = RunContextWrapper(EnhancedContextData(working_directory=os.getcwd()))
+    object.__setattr__(wrapper.context, "count_tokens", lambda text: len(text))
+
+    # Initial read to populate cache
+    asyncio.run(read_file.on_invoke_tool(wrapper, json.dumps({"params": {"file_path": str(file_path)}})))
+
+    # Patch open to ensure cache is used
+    with patch("builtins.open", side_effect=AssertionError("open called")):
+        result = asyncio.run(read_file.on_invoke_tool(wrapper, json.dumps({"params": {"file_path": str(file_path)}})))
+
+    assert result["content"] == "hello"
+
+
+def test_read_file_cache_invalidation(tmp_path):
+    _file_cache.clear()
+    file_path = tmp_path / "sample.txt"
+    file_path.write_text("hello")
+    wrapper = RunContextWrapper(EnhancedContextData(working_directory=os.getcwd()))
+    object.__setattr__(wrapper.context, "count_tokens", lambda text: len(text))
+
+    # Populate cache
+    asyncio.run(read_file.on_invoke_tool(wrapper, json.dumps({"params": {"file_path": str(file_path)}})))
+
+    # Modify file to change mtime and size
+    file_path.write_text("hello world")
+
+    from builtins import open as builtin_open
+    with patch("builtins.open", wraps=builtin_open) as mock_open:
+        result = asyncio.run(read_file.on_invoke_tool(wrapper, json.dumps({"params": {"file_path": str(file_path)}})))
+
+    assert result["content"] == "hello world"
+    assert mock_open.call_count == 1


### PR DESCRIPTION
## Summary
- cache file reads in `read_file` to avoid disk hits when unchanged
- reuse cached reads for manual context and context tracking
- add tests covering caching and invalidation

## Testing
- `pytest tests/test_read_file_cache.py -q`
- `pytest -q` *(fails: OSError: [E050] Can't find model 'en_core_web_lg')*
- `python -m spacy download en_core_web_lg` *(fails: ProxyError: Unable to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689b603accb08329bd30ef92d8bd2f32