### PR TITLE
Use asyncio executor for spaCy processing

### DIFF
--- a/The_Agents/spacy_singleton.py
+++ b/The_Agents/spacy_singleton.py
@@ -115,9 +115,10 @@ class SpacyModelSingleton:
         """
         # Make sure NLP is initialized
         await self._ensure_initialized()
-            
-        # Process the text
-        doc = self.nlp(text)
+
+        # Process the text using a thread executor to avoid blocking
+        loop = asyncio.get_running_loop()
+        doc = await loop.run_in_executor(None, self.nlp, text)
         return doc
     
     async def extract_entities(self, text: str) -> Dict[str, List[Dict[str, Any]]]:


### PR DESCRIPTION
## Summary
- process_text offloads spaCy calls to run_in_executor to avoid blocking the event loop

## Testing
- `pytest` *(fails: Can't find model 'en_core_web_lg')*
- `python -m spacy download en_core_web_lg` *(fails: ProxyError 403 when downloading)*

------
https://chatgpt.com/codex/tasks/task_e_689b759fa0188329b7ff6ebed6030174