### PR TITLE
Improve tool name extraction for nested SDK attributes

### DIFF
--- a/fix_streaming_issue.py
+++ b/fix_streaming_issue.py
@@ -160,8 +160,20 @@ async def handle_stream_events_improved(stream_events, context, item_helpers):
                 if item:
                     # Tool call
                     if hasattr(item, 'type') and 'tool_call' in item.type:
-                        tool_name = getattr(item, 'name', None) or getattr(item, 'tool_name', 'Unknown tool')
-                        params = getattr(item, 'params', None) or getattr(item, 'input', {})
+                        # Agents SDK may nest tool metadata under item.call.tool
+                        # See Docs/openai_agents_sdk_docs/tools.md
+                        tool_name = (
+                            getattr(item, 'name', None)
+                            or getattr(item, 'tool_name', None)
+                            or getattr(getattr(getattr(item, 'call', None), 'tool', None), 'name', None)
+                        ) or 'Unknown tool'
+                        params = (
+                            getattr(item, 'params', None)
+                            or getattr(item, 'input', None)
+                            or getattr(getattr(item, 'call', None), 'arguments', None)
+                            or getattr(getattr(item, 'call', None), 'params', None)
+                            or getattr(getattr(item, 'call', None), 'input', None)
+                        ) or {}
                         
                         print(f"\\n{YELLOW}⚙{RESET} Calling: {tool_name}", flush=True)
                         

--- a/utilities/improved_stream_handler.py
+++ b/utilities/improved_stream_handler.py
@@ -62,8 +62,20 @@ async def handle_stream_events_improved(stream_events, context, logger=None, ite
                 if item:
                     # Tool call
                     if hasattr(item, 'type') and 'tool_call' in item.type:
-                        tool_name = getattr(item, 'name', None) or getattr(item, 'tool_name', 'Unknown tool')
-                        params = getattr(item, 'params', None) or getattr(item, 'input', {})
+                        # Agents SDK may nest tool metadata under item.call.tool
+                        # See Docs/openai_agents_sdk_docs/tools.md
+                        tool_name = (
+                            getattr(item, 'name', None)
+                            or getattr(item, 'tool_name', None)
+                            or getattr(getattr(getattr(item, 'call', None), 'tool', None), 'name', None)
+                        ) or 'Unknown tool'
+                        params = (
+                            getattr(item, 'params', None)
+                            or getattr(item, 'input', None)
+                            or getattr(getattr(item, 'call', None), 'arguments', None)
+                            or getattr(getattr(item, 'call', None), 'params', None)
+                            or getattr(getattr(item, 'call', None), 'input', None)
+                        ) or {}
                         
                         print(f"\n{YELLOW}⚙{RESET} Calling: {tool_name}", flush=True)
                         


### PR DESCRIPTION
## Summary
- Enhance stream handlers to resolve tool names and parameters from nested `item.call.tool` structures
- Apply same logic to legacy fix script for consistency
- Document Agents SDK nesting reference in code comments

## Testing
- `pytest` *(fails: SyntaxError in The_Agents/context_data.py and import errors)*
- `python - <<'PY' ...` (simulated event prints `⚙ Calling: dummy_tool`)
- `python examples/Example_Agent_with_apply_patch.py` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_689baaf1829c8329ae354f204123c460