### PR TITLE
centralize logging configuration

### DIFF
--- a/The_Agents/ArchitectAgent.py
+++ b/The_Agents/ArchitectAgent.py
@@ -15,20 +15,14 @@ import logging
 import json
 import re
 import time
-from logging.handlers import RotatingFileHandler
 
 # Import tool usage utilities
 from utilities.tool_usage import handle_stream_events
 
-# Configure logger for ArchitectAgent
+from utilities.logging_setup import setup_logging
+
+setup_logging(__name__)
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-os.makedirs("logs", exist_ok=True)
-architect_handler = RotatingFileHandler('logs/architectagent.log', maxBytes=10*1024*1024, backupCount=3)
-architect_handler.setLevel(logging.DEBUG)
-architect_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(message)s'))
-logger.addHandler(architect_handler)
-logger.propagate = False
 
 # ANSI color codes for REPL
 GREEN = "\033[32m"

--- a/The_Agents/SingleAgent.py
+++ b/The_Agents/SingleAgent.py
@@ -15,7 +15,6 @@ import logging
 import json
 import re
 import time
-from logging.handlers import RotatingFileHandler
 
 # Import prompt_toolkit components
 from prompt_toolkit import PromptSession
@@ -34,15 +33,10 @@ try:
 except ImportError:
     from utilities.tool_usage import handle_stream_events
 
-# Configure logger for SingleAgent
+from utilities.logging_setup import setup_logging
+
+setup_logging(__name__)
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-os.makedirs("logs", exist_ok=True)
-single_handler = RotatingFileHandler('logs/singleagent.log', maxBytes=10*1024*1024, backupCount=3)
-single_handler.setLevel(logging.DEBUG)
-single_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(message)s'))
-logger.addHandler(single_handler)
-logger.propagate = False
 
 # ANSI color codes for REPL
 GREEN = "\033[32m"

--- a/Tools/singleagent_tools.py
+++ b/Tools/singleagent_tools.py
@@ -28,7 +28,6 @@ import os
 from agents import function_tool, RunContextWrapper
 from The_Agents.context_data import EnhancedContextData
 import logging
-from logging.handlers import RotatingFileHandler
 
 # Import shared tools and utilities
 from .shared_tools import (
@@ -37,17 +36,10 @@ from .shared_tools import (
     GetContextParams, GetContextResponse, AddManualContextParams, RunCommandParams, FileReadParams
 )
 
-# Configure logger for tools
-tool_logger = logging.getLogger(__name__)
-tool_logger.setLevel(logging.DEBUG)
-# rotating file handler for tools.log
-tools_handler = RotatingFileHandler('logs/tools.log', maxBytes=10*1024*1024, backupCount=3)
-tools_handler.setLevel(logging.DEBUG)
-tools_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(message)s'))
-tool_logger.addHandler(tools_handler)
-tool_logger.propagate = False
-# alias tool_logger as logger for use in function implementations
-logger = tool_logger
+from utilities.logging_setup import setup_logging
+
+setup_logging(__name__)
+logger = logging.getLogger(__name__)
 
 # Models for tool parameters (no default values as required for Pydantic v2 compatibility)
 

--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ import json
 import os
 from functools import lru_cache
 from datetime import datetime
-from logging.handlers import RotatingFileHandler
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
@@ -48,16 +47,10 @@ BOLD  = "\033[1m"
 RESET = "\033[0m"
 
 # Configure logging
-os.makedirs("logs", exist_ok=True)
-root_logger = logging.getLogger()
-root_logger.setLevel(logging.DEBUG)
-# Remove default handlers
-for handler in root_logger.handlers[:]:
-    root_logger.removeHandler(handler)
-main_handler = RotatingFileHandler('logs/main.log', maxBytes=10*1024*1024, backupCount=3)
-main_handler.setLevel(logging.DEBUG)
-main_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(message)s'))
-root_logger.addHandler(main_handler)
+from utilities.logging_setup import setup_logging
+
+setup_logging(__name__)
+logger = logging.getLogger(__name__)
 
 # Enhanced agent modes
 class AgentMode:

--- a/utilities/logging_setup.py
+++ b/utilities/logging_setup.py
@@ -1,0 +1,61 @@
+"""Centralized logging configuration for the project."""
+
+from __future__ import annotations
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+
+# Internal flag to avoid reconfiguring the root logger multiple times
+_ROOT_CONFIGURED = False
+
+
+def setup_logging(name: str, level: int = logging.DEBUG) -> logging.Logger:
+    """Configure logging for the given module name.
+
+    This function configures the root logger on first use and creates a
+    rotating file handler for the specified logger. The logger is returned so
+    callers can further customize if needed.
+
+    Parameters
+    ----------
+    name:
+        Name of the logger to configure. Typically ``__name__`` of the calling
+        module.
+    level:
+        Logging level for both the root and child loggers. Defaults to
+        ``logging.DEBUG``.
+    """
+
+    global _ROOT_CONFIGURED
+
+    os.makedirs("logs", exist_ok=True)
+
+    # Configure the root logger only once
+    root_logger = logging.getLogger()
+    if not _ROOT_CONFIGURED:
+        root_logger.setLevel(level)
+        for handler in root_logger.handlers[:]:
+            root_logger.removeHandler(handler)
+        _ROOT_CONFIGURED = True
+
+    # Create and configure the child logger
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+
+    if not logger.handlers:
+        handler = RotatingFileHandler(
+            f"logs/{name}.log", maxBytes=10 * 1024 * 1024, backupCount=3
+        )
+        handler.setLevel(level)
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+        )
+        logger.addHandler(handler)
+        logger.propagate = False
+
+    return logger
+
+
+__all__ = ["setup_logging"]
+


### PR DESCRIPTION
## Summary
- add utilities.logging_setup module providing setup_logging helper
- use setup_logging across agents and tools for consistent logger initialization

## Testing
- `pytest` *(fails: OSError: Can't find model 'en_core_web_lg')*

------
https://chatgpt.com/codex/tasks/task_e_68a52e91fd808329918be17971e37282