### PR TITLE
feat: add sqlite persistence for shared context

### DIFF
--- a/tests/test_shared_context_sqlite.py
+++ b/tests/test_shared_context_sqlite.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from The_Agents.shared_context_manager import SharedContextManager, TaskPriority
+
+
+def test_sqlite_persistence(tmp_path):
+    db_file = tmp_path / "shared_context.db"
+    mgr = SharedContextManager(db_path=str(db_file))
+
+    task_id = mgr.add_task(
+        target_agent="code",
+        task="Implement feature",
+        created_by="architect",
+        priority=TaskPriority.HIGH,
+    )
+    insight_id = mgr.add_insight(
+        agent="architect",
+        insight="Use SQLite for persistence",
+        category="architecture",
+    )
+
+    # Recreate manager to ensure data is persisted to disk
+    mgr2 = SharedContextManager(db_path=str(db_file))
+    assert task_id in mgr2.tasks
+    assert insight_id in mgr2.insights
+


### PR DESCRIPTION
## Summary
- add SQLite-backed persistence to `SharedContextManager`
- implement lightweight store to create tables and save/load tasks, insights and decisions
- verify persistence with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a531f1b7c88329bb567e736cda380a